### PR TITLE
Use HTTPS to download Clojure jar files

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -57,7 +57,7 @@ downloaded_file_path() {
 
 jar_download_url() {
   local version=$1
-  echo "http://repo1.maven.org/maven2/org/clojure/clojure/${version}/clojure-${version}.jar"
+  echo "https://repo1.maven.org/maven2/org/clojure/clojure/${version}/clojure-${version}.jar"
 }
 
 installer "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"


### PR DESCRIPTION
HTTPS is required by maven.org now.