### PR TITLE
Fix clj bin path

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -31,6 +31,7 @@ install() {
     cd "$distination_path"
     grep -v -i ruby install.sh >install-without-ruby.sh
     sed -i.bak "s|PREFIX|\"${install_path}\"|g" clojure
+    sed -i.bak "s|BINDIR|\"${install_path}/bin\"|g" clj
 
     mkdir -p "$install_path"
     chmod +x install-without-ruby.sh


### PR DESCRIPTION
I've just been trying asdf and when trying it with Clojure I noticed that while the `clojure` command works just fine, the repl version`clj` was throwing an rlwrap error related to BINDIR. Turns out the install script is just missing the equivalent substitution from the original script.

For context, this is what's in the original script:
```
${HOMEBREW_RUBY_PATH} -pi.bak -e "gsub(/PREFIX/, '$prefix')" clojure
${HOMEBREW_RUBY_PATH} -pi.bak -e "gsub(/BINDIR/, '$prefix/bin')" clj
```

Hope this helps!